### PR TITLE
Add check for assertions to be undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,16 @@ function createLightSummary(rawDetail, options) {
   let steps = [];
   rawDetail.run.executions.forEach(function (exec) {
     let assertions = [];
-    exec.assertions.forEach(function (assertionReport) {
-      assertions.push({
-        'name': assertionReport.assertion,
-        'skipped': assertionReport.skipped,
-        'failed': assertionReport.error !== undefined,
-        'errorMessage': assertionReport.error ? assertionReport.error.message : undefined
+    if(exec.assertions !== undefined) {
+      exec.assertions.forEach(function (assertionReport) {
+        assertions.push({
+          'name': assertionReport.assertion,
+          'skipped': assertionReport.skipped,
+          'failed': assertionReport.error !== undefined,
+          'errorMessage': assertionReport.error ? assertionReport.error.message : undefined
+        });
       });
-    });
+    }
     let step = {};
     let request = {};
     Object.assign(request, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-json-steps",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "JSON reporter oriented on step results of Newman execution.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello, I would like to build in this check. The reporter crashes whenever assertions aren't there in the collection. Therefor, it's not able to run the reporter. 

Please see if this is considerable or not. 